### PR TITLE
Add Stomp.Proc.map and expose expiresAfter

### DIFF
--- a/src/Stomp/Proc.elm
+++ b/src/Stomp/Proc.elm
@@ -80,6 +80,8 @@ init cmd =
         }
 
 
+{-| Add expiration header to the request message.
+-}
 expiresAfter : Float -> RemoteProcedure msg -> RemoteProcedure msg
 expiresAfter milliseconds =
     withHeader ( "expiration", String.fromFloat milliseconds )

--- a/src/Stomp/Proc.elm
+++ b/src/Stomp/Proc.elm
@@ -3,6 +3,7 @@ module Stomp.Proc exposing
     , withHeader, withHeaders, withPayload
     , onResponse, expectJson
     , batch, none
+    , expiresAfter, map
     )
 
 {-| A remote procedure call (the request/response pattern).
@@ -156,3 +157,8 @@ batch =
 none : RemoteProcedure msg
 none =
     Stomp.Internal.Batch.none
+
+
+map : (a -> b) -> RemoteProcedure a -> RemoteProcedure b
+map func =
+    Stomp.Internal.Batch.map (Stomp.Internal.Proc.map func)

--- a/src/Stomp/Proc.elm
+++ b/src/Stomp/Proc.elm
@@ -161,6 +161,8 @@ none =
     Stomp.Internal.Batch.none
 
 
+{-| Map a remote procedure of msg a to a remote procedure of msg b.
+-}
 map : (a -> b) -> RemoteProcedure a -> RemoteProcedure b
 map func =
     Stomp.Internal.Batch.map (Stomp.Internal.Proc.map func)


### PR DESCRIPTION
### Problem

a) map helper function missing that is heavily used in the previous version of elm-stomp.
b) expiresAfter is not exposed and thus can't be used outside of the Proc-module.

### Solution

a) Add map helper function
b) Expose expiresAfter
